### PR TITLE
:bug: Fixes TypeError on tokenInfo.symbol undefined

### DIFF
--- a/src/providers/Uniswap/index.tsx
+++ b/src/providers/Uniswap/index.tsx
@@ -41,7 +41,7 @@ export async function loadUniswapPairInfo(
   };
 }
 
-export const isUniswapSymbol = (symbol: string) => symbol.startsWith("UNI-V2");
+export const isUniswapSymbol = (symbol: string) => symbol && symbol.startsWith("UNI-V2");
 
 
 export type BN = ReturnType<typeof web3.utils.toBN>


### PR DESCRIPTION
This is happening because the data pull from the `getAddressInfo`
endpoint may contain tokens without `symbol` key.
In the sample below the `0xa1484c3aa22a66c62b77e0ae78e15258bd0cb711`
token doesn't have a `symbol`.
```json
{
  "address": "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
  "ETH": {
    "balance": 1.234,
    "price": {
      "rate": 356.725103558,
      "diff": -1.97,
      "diff7d": 3.84,
      "ts": 1601407645,
      "marketCapUsd": 40240352275.438965,
      "availableSupply": 112804935.4365,
      "volume24h": 10453095952.5145,
      "diff30d": -13.83580706094358
    }
  },
  "countTxs": 395,
  "tokens": [
    {
      "tokenInfo": {
        "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
        "decimals": "18",
        "name": "Uniswap",
        "owner": "0x",
        "symbol": "UNI",
        "totalSupply": "1000000000000000000000000000",
        "lastUpdated": 1601406351,
        "issuancesCount": 0,
        "holdersCount": 84452,
        "price": {
          "rate": 4.31880661507,
          "diff": -1.05,
          "diff7d": 6.34,
          "ts": 1601407525,
          "marketCapUsd": 418346752.4352559,
          "availableSupply": 96866285,
          "volume24h": 415572036.388497,
          "currency": "USD"
        }
      },
      "balance": 1.2345,
      "totalIn": 0,
      "totalOut": 0
    },
    {
      "tokenInfo": {
        "address": "0x2e071d2966aa7d8decb1005885ba1977d6038a65",
        "name": "Etheroll",
        "decimals": "16",
        "symbol": "DICE",
        "totalSupply": "70016226487944217315546",
        "owner": "0x73f0ed546cd7893abc5e04284b68522602603dd4",
        "lastUpdated": 1601346289,
        "issuancesCount": 0,
        "holdersCount": 1637,
        "image": "/images/DICE2e071d29.png",
        "website": "https://etheroll.com/",
        "twitter": "etheroll",
        "reddit": "etheroll",
        "ethTransfersCount": 8,
        "price": {
          "rate": 0.422139453395,
          "diff": 0,
          "diff7d": -1.22,
          "ts": 1601407503,
          "marketCapUsd": 2955661.1578401285,
          "availableSupply": 7001622.64879442,
          "volume24h": 0,
          "diff30d": -20.417074493355486,
          "currency": "USD"
        }
      },
      "balance": 1234,
      "totalIn": 0,
      "totalOut": 0
    },
    {
      "tokenInfo": {
        "address": "0x3b3d4eefdc603b232907a7f3d0ed1eea5c62b5f7",
        "name": "Uniswap V2",
        "decimals": "18",
        "symbol": "UNI-V2",
        "totalSupply": "12430456086749978514038",
        "owner": "0x",
        "lastUpdated": 1601404722,
        "issuancesCount": 0,
        "holdersCount": 294,
        "price": false
      },
      "balance": 1.234,
      "totalIn": 0,
      "totalOut": 0
    },
    {
      "tokenInfo": {
        "address": "0xa1484c3aa22a66c62b77e0ae78e15258bd0cb711",
        "decimals": "0",
        "owner": "0x",
        "totalSupply": "8058935521435854969133595",
        "lastUpdated": 1601406347,
        "issuancesCount": 0,
        "holdersCount": 6,
        "price": false
      },
      "balance": 1234,
      "totalIn": 0,
      "totalOut": 0
    }
  ]
}
```
Also see stacktrace:
![image](https://user-images.githubusercontent.com/24973/94608747-22fc9900-029e-11eb-959c-cb082b5abc72.png)
And debugging session:
![image](https://user-images.githubusercontent.com/24973/94608655-fe082600-029d-11eb-818b-ee1a67c50911.png)
